### PR TITLE
Fix deletion order in TestRanking#setup

### DIFF
--- a/test/models/test_gems.rb
+++ b/test/models/test_gems.rb
@@ -4,9 +4,9 @@ require_relative '../run_migration'
 
 class TestRanking < MiniTest::Unit::TestCase
   def setup
-    Gems.where.delete
     Value.where.delete
     Ranking.where.delete
+    Gems.where.delete
   end
 
   def test_search


### PR DESCRIPTION
If you delete `Gems` before `Value` or `Ranking`, `Sequel::ForeignKeyConstraintViolation: SQLite3::ConstraintException: FOREIGN KEY constraint failed` is raised because `Value` and `Ranking` reference `Gems`.
