### PR TITLE
ignore duplicate scraped data

### DIFF
--- a/lib/batch/update_total_downloads.rb
+++ b/lib/batch/update_total_downloads.rb
@@ -13,8 +13,12 @@ class TotalDownloadsUpdater
   end
 
   def self.generate_total_downloads_from_scraped_data(date)
+    duplicate_checker = {}
     total_downloads = []
     ScrapedData.where(:date => date).order(:name).each{|data|
+      next if duplicate_checker[data[:name]]
+      duplicate_checker[data[:name]] = true
+
       gem = Gems.where(:name => data[:name]).first
       raise 'Database inconsistency.' unless gem
 

--- a/test/batch/test_update_total_downloads.rb
+++ b/test/batch/test_update_total_downloads.rb
@@ -35,6 +35,11 @@ class TestUpdateTotalDownloads < MiniTest::Unit::TestCase
                        :date => Date.new(2014, 6, 1),
                        :name => 'bar',
                        :downloads => 84)
+    # duplicate record. this is should be ignored.
+    ScrapedData.insert(:id => 3,
+                       :date => Date.new(2014, 6, 1),
+                       :name => 'bar',
+                       :downloads => 84)
     Gems.insert(:id => 1,
                 :name => 'foo')
     Gems.insert(:id => 2,


### PR DESCRIPTION
In rare cases, `scraping_all_gems.rb` stores duplicate data to `scraped_data` table.
Presumably, this phenomenon is caused by increasing number of gems while scraping.
`update_total_downloads.rb` should ignore those duplicate scraped data.
