### PR TITLE
Fix serious performance probrem

### DIFF
--- a/lib/models/ranking.rb
+++ b/lib/models/ranking.rb
@@ -60,7 +60,7 @@ class Ranking < Sequel::Model
         total_ranking: gem[:latest_total_ranking],
         daily_ranking: gem[:latest_daily_ranking]
       }
-    }
+    }.sort_by{|gem| gem[:ranking]}
   end
 
   def self.featured_count(date)

--- a/migrations/007_add_index_to_gems.rb
+++ b/migrations/007_add_index_to_gems.rb
@@ -1,0 +1,19 @@
+Sequel.migration do
+  up do
+    transaction do
+      alter_table(:gems) do
+        add_index [:latest_update_date, :latest_total_ranking]
+        add_index [:latest_update_date, :latest_daily_ranking]
+      end
+    end
+  end
+
+  down do
+    transaction do
+      alter_table(:gems) do
+        drop_index [:latest_update_date, :latest_total_ranking]
+        drop_index [:latest_update_date, :latest_daily_ranking]
+      end
+    end
+  end
+end

--- a/test/models/test_ranking.rb
+++ b/test/models/test_ranking.rb
@@ -1,5 +1,6 @@
 require 'minitest/autorun'
 require 'database'
+require 'batch/update_gems_latest_columns'
 require_relative '../run_migration'
 
 class TestRanking < Minitest::Test
@@ -12,16 +13,23 @@ class TestRanking < Minitest::Test
                 :name => 'foo',
                 :version => '1.0',
                 :summary => 'Awesome gem.')
-    Value.insert(:id => 1,
-                 :type => Value::Type::TOTAL_DOWNLOADS,
+    Value.insert(:type => Value::Type::TOTAL_DOWNLOADS,
                  :gem_id => 1,
                  :date => Date.new(2014, 6, 1),
                  :value => 42)
-    Ranking.insert(:id => 1,
-                   :type => Ranking::Type::TOTAL_RANKING,
+    Ranking.insert(:type => Ranking::Type::TOTAL_RANKING,
                    :gem_id => 1,
                    :date => Date.new(2014, 6, 1),
                    :ranking => 20)
+    Value.insert(:type => Value::Type::DAILY_DOWNLOADS,
+                 :gem_id => 1,
+                 :date => Date.new(2014, 6, 1),
+                 :value => 23)
+    Ranking.insert(:type => Ranking::Type::DAILY_RANKING,
+                   :gem_id => 1,
+                   :date => Date.new(2014, 6, 1),
+                   :ranking => 10)
+    GemsLatestColumnsUpdater.execute(Date.new(2014, 6, 1))
 
     total = Ranking.total(Date.new(2014, 6, 1), 1)
     top = total.first
@@ -37,23 +45,30 @@ class TestRanking < Minitest::Test
                 :name => 'foo',
                 :version => '1.0',
                 :summary => 'Awesome gem.')
-    Value.insert(:id => 1,
-                 :type => Value::Type::DAILY_DOWNLOADS,
+    Value.insert(:type => Value::Type::TOTAL_DOWNLOADS,
                  :gem_id => 1,
                  :date => Date.new(2014, 6, 1),
                  :value => 42)
-    Ranking.insert(:id => 1,
-                   :type => Ranking::Type::DAILY_RANKING,
+    Ranking.insert(:type => Ranking::Type::TOTAL_RANKING,
+                   :gem_id => 1,
+                   :date => Date.new(2014, 6, 1),
+                   :ranking => 20)
+    Value.insert(:type => Value::Type::DAILY_DOWNLOADS,
+                 :gem_id => 1,
+                 :date => Date.new(2014, 6, 1),
+                 :value => 23)
+    Ranking.insert(:type => Ranking::Type::DAILY_RANKING,
                    :gem_id => 1,
                    :date => Date.new(2014, 6, 1),
                    :ranking => 10)
+    GemsLatestColumnsUpdater.execute(Date.new(2014, 6, 1))
 
     daily = Ranking.daily(Date.new(2014, 6, 1), 1)
     top = daily.first
 
     assert_equal 'foo', top[:name]
     assert_equal 'Awesome gem.', top[:summary]
-    assert_equal 42, top[:downloads]
+    assert_equal 23, top[:downloads]
     assert_equal 10, top[:ranking]
   end
 
@@ -62,26 +77,31 @@ class TestRanking < Minitest::Test
                 :name => 'foo',
                 :version => '1.0',
                 :summary => 'Awesome gem.')
-    Value.insert(:id => 1,
-                 :type => Value::Type::FEATURED_SCORE,
+    Value.insert(:type => Value::Type::TOTAL_DOWNLOADS,
                  :gem_id => 1,
                  :date => Date.new(2014, 6, 1),
-                 :value => 10)
-    Ranking.insert(:id => 1,
-                   :type => Ranking::Type::TOTAL_RANKING,
+                 :value => 42)
+    Ranking.insert(:type => Ranking::Type::TOTAL_RANKING,
                    :gem_id => 1,
                    :date => Date.new(2014, 6, 1),
                    :ranking => 20)
-    Ranking.insert(:id => 2,
-                   :type => Ranking::Type::DAILY_RANKING,
+    Value.insert(:type => Value::Type::DAILY_DOWNLOADS,
+                 :gem_id => 1,
+                 :date => Date.new(2014, 6, 1),
+                 :value => 23)
+    Ranking.insert(:type => Ranking::Type::DAILY_RANKING,
                    :gem_id => 1,
                    :date => Date.new(2014, 6, 1),
                    :ranking => 10)
-    Ranking.insert(:id => 3,
-                   :type => Ranking::Type::FEATURED_RANKING,
+    Value.insert(:type => Value::Type::FEATURED_SCORE,
+                 :gem_id => 1,
+                 :date => Date.new(2014, 6, 1),
+                 :value => 10)
+    Ranking.insert(:type => Ranking::Type::FEATURED_RANKING,
                    :gem_id => 1,
                    :date => Date.new(2014, 6, 1),
                    :ranking => 30)
+    GemsLatestColumnsUpdater.execute(Date.new(2014, 6, 1))
 
     featured = Ranking.featured(Date.new(2014, 6, 1), 1)
     top = featured.first


### PR DESCRIPTION
To fetch rankings from `rankings` table is too slow.
Fetch rankings from `gems` table instead of `rainkings` table.