### PR TITLE
Trend server configuration

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -1,0 +1,13 @@
+module Config
+  def self.trend_drb_bind_uri
+    ENV["BESTGEMS_TREND_DRB_BIND_URI"] || "druby://localhost:16330"
+  end
+
+  def self.trend_drb_uri
+    ENV["BESTGEMS_TREND_DRB_URI"] || "druby://localhost:16330"
+  end
+
+  def self.trend_server
+    ENV["BESTGEMS_TREND_SERVER"] == "true"
+  end
+end

--- a/lib/database.rb
+++ b/lib/database.rb
@@ -1,9 +1,10 @@
-require "logger"
+require_relative "config"
 
+require "logger"
 require "sinatra"
 require "sinatra/config_file"
 config_file File.expand_path("../../config/database.yml.erb", __FILE__)
-Settings = settings
+Settings = settings # TODO: Get all settings from the Config module
 
 require "sequel"
 require "cgi"

--- a/lib/models/trend.rb
+++ b/lib/models/trend.rb
@@ -1,6 +1,4 @@
-TREND_DRB_URI = "druby://localhost:16330"
-
-if ENV["BESTGEMS_TREND_SERVER"] == "true"
+if Config.trend_server
   class Trend
     include DRb::DRbUndumped
 
@@ -90,7 +88,7 @@ if ENV["BESTGEMS_TREND_SERVER"] == "true"
     end
   end
 
-  DRb.start_service(TREND_DRB_URI, Trend, safe_level: 1)
+  DRb.start_service(Config.trend_drb_bind_uri, Trend, safe_level: 1)
 else
-  Trend = DRbObject.new_with_uri(TREND_DRB_URI)
+  Trend = DRbObject.new_with_uri(Config.trend_drb_uri)
 end


### PR DESCRIPTION
Changes for server migration.

With Docker, the server and batch processes are on separate networks, so we're making these changes:

* Specify the trend server's bind address. `BESTGEMS_TREND_DRB_BIND_URI`
* Set the destination for the trend server. `BESTGEMS_TREND_DRB_URI`