### PR TITLE
Add endpoint for all downloads for a particular day

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -569,6 +569,12 @@ put "/api/v2/gems/:name/owners.json" do
   end
 end
 
+get "/api/v2/days/:date/downloads.json" do
+  api_handler do
+    Statistics.day_as_json(params[:date]).to_json
+  end
+end
+
 get "/api/v2/statistics/gems/count.json" do
   api_handler do
     Statistics.gems_count_as_json.to_json

--- a/lib/models/statistics.rb
+++ b/lib/models/statistics.rb
@@ -73,6 +73,10 @@ class Statistics < Sequel::Model
     end
   end
 
+  def self.day_as_json(date)
+    self.where(:date => date).order(:name).map(&:as_json)
+  end
+
   def as_json
     {
       value: value,


### PR DESCRIPTION
Sorry, I was unable to get the app working locally to test this, but I think this should give an idea of the endpoint I would like to add

It would make it easy to keep a mirror of the data up-to-date locally, by only requiring one new download a day, as opposed to needing to download all 180k gems every day